### PR TITLE
chore: Update internal code to work with shiny v1.12.0

### DIFF
--- a/R/action.R
+++ b/R/action.R
@@ -36,7 +36,18 @@ inline_link = function(id, label, icon = NULL, meaning = label, accent = NULL)
             } else "inshiny-link")
 
     # Check structure is as expected
-    check_tags(widget, shiny::a(), "shiny::actionLink()")
+    if (packageVersion("shiny") > "1.11.1") {
+        check_tags(
+            widget,
+            shiny::tags$a(
+                if (!is.null(icon)) shiny::tags$span(shiny::tags$i()),
+                shiny::tags$span()
+            ),
+            "shiny::actionLink()"
+        )
+    } else {
+        check_tags(widget, shiny::tags$a(), "shiny::actionLink()")
+    }
 
     return (coalesce(widget))
 }

--- a/R/helper.R
+++ b/R/helper.R
@@ -73,7 +73,8 @@ coalesce = function(html)
     }
 
     for (i in seq_along(html$children)) {
-        html$children[[i]] = coalesce(html$children[[i]])
+        # Allow for `NULL` children
+        html$children[i] = list(coalesce(html$children[[i]]))
     }
 
     return (html)


### PR DESCRIPTION
Hello, I'm a core contributor to Shiny, and this PR is addressing changes made in https://github.com/rstudio/shiny/pull/4249, where we made changes to the HTML markup that actionButton() produces, which will break some of prompter's tests running on CRAN.

If you could submit these changes to CRAN to avoid a reverse dependency failure for Shiny, that'd be greatly appreciated! We plan to submit in 2 weeks or earlier if all reverse dependencies are addressed.

Thank you!

-----------------

As a side note, I strongly recommend having `check_tags()` be able to be opt-out (`check = FALSE`). If a tag structure changes that isn't covered by your tests, users will immediately have their app stop when it is probably ok.

I'd even go further to suggest that the check _only_ be performed during CI tests.
